### PR TITLE
Use pumpAndSettle in widget test

### DIFF
--- a/mobile-app/test/widget_test.dart
+++ b/mobile-app/test/widget_test.dart
@@ -14,6 +14,7 @@ void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const AIStockSummaryApp(firebaseEnabled: false));
+    await tester.pumpAndSettle();
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);
@@ -21,7 +22,7 @@ void main() {
 
     // Tap the '+' icon and trigger a frame.
     await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     // Verify that our counter has incremented.
     expect(find.text('0'), findsNothing);


### PR DESCRIPTION
## Summary
- make widget test settle after pumping widget and tapping + icon

## Testing
- `flutter test` *(fails: Expected: exactly one matching candidate Actual: _TextWidgetFinder:<Found 0 widgets with text "0": []>)*

------
https://chatgpt.com/codex/tasks/task_e_688dcc37d894832981ea7528942a94b0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by ensuring UI is fully settled before assertions, leading to more stable and accurate test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->